### PR TITLE
Set `throw` to be marked as keyword instead of unassigned variable

### DIFF
--- a/server/src/lexer.ts
+++ b/server/src/lexer.ts
@@ -2182,7 +2182,7 @@ export class Lexer {
 						break;
 					case 'throw':
 						if (ahk_version >= alpha_3) {
-							tk.type = 'TK_WORD', next = false;
+							tk.type = 'TK_RESERVED', next = true;
 							break;
 						}
 					// fall through


### PR DESCRIPTION
Fixes https://github.com/mark-wiemer/ahkpp/issues/602.