### PR TITLE
Fix build errors

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,18 +1,41 @@
 // https://github.com/microsoft/vscode-test-cli
 import { defineConfig } from '@vscode/test-cli';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
-let timeout, vscode_path;
-if (process.execPath.toLowerCase().endsWith('code.exe')) timeout = 0;
-else {
+function findVSCodePath() {
+	const installPaths = [
+		process.env.VSCODE_EXEC_PATH,
+		process.env.LOCALAPPDATA &&
+			join(
+				process.env.LOCALAPPDATA,
+				'Programs',
+				'Microsoft VS Code',
+				'Code.exe',
+			),
+	];
+	const installPath = installPaths.find(
+		(path) => typeof path === 'string' && existsSync(path),
+	);
+	if (installPath) return installPath;
+
+	if (process.platform !== 'win32') return undefined;
+
 	try {
-		const m = execSync(
-			'chcp 65001 && reg query HKCR\\vscode\\shell\\open\\command',
+		const match = execFileSync(
+			'reg.exe',
+			['query', 'HKCR\\vscode\\shell\\open\\command'],
 			{ encoding: 'utf8' },
 		).match(/REG_SZ\s+("([^"]+)"|\S+)/);
-		vscode_path = m[2] || m[1];
-	} catch {}
+		const registryPath = match?.[2] || match?.[1];
+		return registryPath && existsSync(registryPath) ? registryPath : undefined;
+	} catch {
+		return undefined;
+	}
 }
+
+const vscodePath = findVSCodePath();
 
 export default defineConfig({
 	files: 'client/dist/test/**/*.e2e.js',
@@ -21,7 +44,7 @@ export default defineConfig({
 		failZero: true,
 		timeout: 60_000,
 	},
-	useInstallation: vscode_path && {
-		fromPath: vscode_path,
+	useInstallation: vscodePath && {
+		fromPath: vscodePath,
 	},
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1321,6 +1321,118 @@
 				"@vscode/vsce-sign-win32-x64": "2.0.2"
 			}
 		},
+		"node_modules/@vscode/vsce-sign-alpine-arm64": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.2.tgz",
+			"integrity": "sha512-E80YvqhtZCLUv3YAf9+tIbbqoinWLCO/B3j03yQPbjT3ZIHCliKZlsy1peNc4XNZ5uIb87Jn0HWx/ZbPXviuAQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"alpine"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-alpine-x64": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.2.tgz",
+			"integrity": "sha512-n1WC15MSMvTaeJ5KjWCzo0nzjydwxLyoHiMJHu1Ov0VWTZiddasmOQHekA47tFRycnt4FsQrlkSCTdgHppn6bw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"alpine"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-darwin-arm64": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.2.tgz",
+			"integrity": "sha512-rz8F4pMcxPj8fjKAJIfkUT8ycG9CjIp888VY/6pq6cuI2qEzQ0+b5p3xb74CJnBbSC0p2eRVoe+WgNCAxCLtzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-darwin-x64": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.2.tgz",
+			"integrity": "sha512-MCjPrQ5MY/QVoZ6n0D92jcRb7eYvxAujG/AH2yM6lI0BspvJQxp0o9s5oiAM9r32r9tkLpiy5s2icsbwefAQIw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-arm": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.2.tgz",
+			"integrity": "sha512-Fkb5jpbfhZKVw3xwR6t7WYfwKZktVGNXdg1m08uEx1anO0oUPUkoQRsNm4QniL3hmfw0ijg00YA6TrxCRkPVOQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-arm64": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.2.tgz",
+			"integrity": "sha512-Ybeu7cA6+/koxszsORXX0OJk9N0GgfHq70Wqi4vv2iJCZvBrOWwcIrxKjvFtwyDgdeQzgPheH5nhLVl5eQy7WA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-x64": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.2.tgz",
+			"integrity": "sha512-NsPPFVtLaTlVJKOiTnO8Cl78LZNWy0Q8iAg+LlBiCDEgC12Gt4WXOSs2pmcIjDYzj2kY4NwdeN1mBTaujYZaPg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-win32-arm64": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.2.tgz",
+			"integrity": "sha512-wPs848ymZ3Ny+Y1Qlyi7mcT6VSigG89FWQnp2qRYCyMhdJxOpA4lDwxzlpL8fG6xC8GjQjGDkwbkWUcCobvksQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@vscode/vsce-sign-win32-x64": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmmirror.com/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.2.tgz",
@@ -3002,6 +3114,21 @@
 			"resolved": "https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -725,7 +725,6 @@
 		},
 		"configurationDefaults": {
 			"[ahk2]": {
-				"editor.defaultFormatter": "thqby.vscode-autohotkey2-lsp",
 				"editor.quickSuggestions": {
 					"other": true,
 					"comments": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
 		"noEmit": true,
+		"skipLibCheck": true,
 		"strict": true
 	},
 	"include": ["client/src", "server/src", "util/src"]


### PR DESCRIPTION
Machines without VS Code stable used to fail to run Mocha tests via CLI. Machines with ahkpp installed as well would fail with dupe type declarations. VS Code would mark the "defaultFormatter" prop as invalid, and since it isn't valuable in this fork, it's been removed.