### PR TITLE
Use `process.env.AHKPP_DEBUG` to reduce conflict risk

### DIFF
--- a/client/src/browserClientMain.ts
+++ b/client/src/browserClientMain.ts
@@ -60,7 +60,7 @@ export function activate(context: ExtensionContext) {
 		documentSelector: [{ language: 'ahk2' }],
 		markdown: { isTrusted: true, supportHtml: true },
 		initializationOptions: {
-			extensionUri: !process.env.DEBUG ? context.extensionUri.toString() : unpkg_url(context),
+			extensionUri: !process.env.AHKPP_DEBUG ? context.extensionUri.toString() : unpkg_url(context),
 			commands: Object.keys(request_handlers),
 			...JSON.parse(JSON.stringify(workspace.getConfiguration(configPrefix)))
 		}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -100,8 +100,8 @@ export function activate(context: ExtensionContext): Promise<LanguageClient> {
 
 	/** Absolute path to `server.js` */
 	const extId = context.extension.id;
-	const serverModule = context.asAbsolutePath(`${extId.startsWith('mark-wiemer') ? 'ahk2/' : ''}server/${process.env.DEBUG ? 'out' : 'dist'}/server.js`);
-	logDebug(`Running in ${process.env.DEBUG ? 'debug' : 'prod'} mode`, logFunc);
+	const serverModule = context.asAbsolutePath(`${extId.startsWith('mark-wiemer') ? 'ahk2/' : ''}server/${process.env.AHKPP_DEBUG ? 'out' : 'dist'}/server.js`);
+	logDebug(`Running in ${process.env.AHKPP_DEBUG ? 'debug' : 'prod'} mode`, logFunc);
 	logDebug(`Server module: ${serverModule}`, logFunc);
 
 	// If the extension is launched in debug mode then the debug server options are used

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -4,7 +4,7 @@ import { build, context } from 'esbuild';
 const server_opt = {
 	define: {
 		'process.env.BROWSER': 'false',
-		'process.env.DEBUG': 'false',
+		'process.env.AHKPP_DEBUG': 'false',
 	},
 	entryPoints: ['server/src/server.ts'],
 	format: 'cjs',
@@ -121,7 +121,7 @@ function build_watch(web = false) {
 	};
 	client_opt.entryPoints.push('client/src/**/*.ts');
 	client_opt.logLevel = server_opt.logLevel = util_opt.logLevel = 'silent';
-	server_opt.define['process.env.DEBUG'] = 'true';
+	server_opt.define['process.env.AHKPP_DEBUG'] = 'true';
 	if (web) opts = browser_opts(false);
 	else {
 		server_opt.entryPoints = ['server/src/*.ts'];


### PR DESCRIPTION
Replace the shared DEBUG environment variable with AHKPP_DEBUG in the esbuild defines and both extension activation paths. Other VS Code extensions can set DEBUG to a non-empty value, which previously caused AHK++ to load the uninstalled server/out artifacts.

Works on https://github.com/mark-wiemer/ahkpp/issues/701