### PR TITLE
Fix setting interpreter path

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -24,7 +24,7 @@ export function updateConfig<T>(
 	value: T,
 	isProperty: boolean,
 	configTarget: vscode.ConfigurationTarget | undefined = undefined,
-) {
+): Thenable<void> {
 	debug(
 		`updateConfig(${configKey}, ${JSON.stringify(value)}, ${isProperty}, ${configTarget}`,
 	);
@@ -50,5 +50,5 @@ export function updateConfig<T>(
 				...value,
 			};
 	debug(`newObjectValue: ${JSON.stringify(newObjectValue)}`);
-	configRoot.update(configObjectKey, newObjectValue, configTarget);
+	return configRoot.update(configObjectKey, newObjectValue, configTarget);
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -537,11 +537,13 @@ async function beginDebug(type: 'f' | 'c' | 'p' | 'a') {
 /**
  * Sets the v2 interpreter path via quick pick.
  * Updates the most local configuration target that has a custom interpreter path.
- * If no target has a custom path, updates workspace folder config.
+ * If no target has a custom path, updates global config.
  */
 async function setInterpreter() {
-	// eslint-disable-next-line prefer-const
-	let index = -1, { path: ahkpath, from } = getInterpreterPath();
+	let index = -1;
+	const result = getInterpreterPath();
+	let ahkpath = result.path;
+	const from = result.from;
 	const list: QuickPickItem[] = [], _ = (ahkpath = resolvePath(interpreterPath || ahkpath, undefined, false)).toLowerCase();
 	const pick = window.createQuickPick();
 	let it: QuickPickItem, active: QuickPickItem | undefined, sel: QuickPickItem = { label: '' };
@@ -637,7 +639,10 @@ function getAHKVersion(paths: string[]): Thenable<string[]> {
 	return client.sendRequest(serverGetAHKVersion, paths.map(p => resolvePath(p, undefined, true) || p));
 }
 
-function getInterpreterPath() {
+function getInterpreterPath(): {
+	path: string;
+	from: ConfigurationTarget;
+} {
 	const t = getConfigRoot().inspect(CfgKey.InterpreterPath);
 	let path = '';
 	if (t)
@@ -648,7 +653,7 @@ function getInterpreterPath() {
 		else if ((path = t.globalValue as string))
 			return { path, from: ConfigurationTarget.Global };
 		else path = t.defaultValue as string ?? '';
-	return { path };
+	return { path, from: ConfigurationTarget.Global };
 }
 
 async function onDidChangeInterpreter() {

--- a/client/src/test/extension.e2e.ts
+++ b/client/src/test/extension.e2e.ts
@@ -42,9 +42,10 @@ import {
 	DidChangeConfigurationNotification,
 } from 'vscode-languageclient/node';
 import { readdirSync } from 'fs';
-import { suite, before, test } from 'mocha';
+import { suite, before, after, test } from 'mocha';
 import { serverGetContent } from '../../../util/src/env';
-import { newConfig } from '../../../util/src/config';
+import { CfgKey, newConfig } from '../../../util/src/config';
+import { getConfigRoot, updateConfig } from '../config';
 import { getClient } from './utils';
 
 let client: LanguageClient;
@@ -55,6 +56,36 @@ before(async () => {
 
 test('should be running', async () => {
 	assert.equal(client?.isRunning(), true);
+});
+
+suite('Configuration updates', () => {
+	let originalGlobalValue: unknown;
+
+	before(() => {
+		originalGlobalValue = getConfigRoot().inspect('v2.file')?.globalValue;
+	});
+
+	after(async () => {
+		await getConfigRoot().update(
+			'v2.file',
+			originalGlobalValue,
+			vscode.ConfigurationTarget.Global,
+		);
+	});
+
+	test('persists the interpreter path to user settings', async () => {
+		const interpreterPath = 'C:\\example\\AutoHotkey.exe';
+		await updateConfig(
+			CfgKey.InterpreterPath,
+			interpreterPath,
+			true,
+			vscode.ConfigurationTarget.Global,
+		);
+		const savedValue = getConfigRoot().inspect('v2.file')?.globalValue as
+			| { interpreterPath?: string }
+			| undefined;
+		assert.strictEqual(savedValue?.interpreterPath, interpreterPath);
+	});
 });
 
 suite('Language client request handlers', () => {});

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -68,7 +68,10 @@ async function build_e2e() {
 	const opts = [
 		client_opt,
 		server_opt,
-		{ ...client_opt, entryPoints: [client_opt.entryPoints.pop()] },
+		{
+			...client_opt,
+			entryPoints: [client_opt.entryPoints.pop(), 'client/src/config.ts'],
+		},
 		util_opt,
 	];
 	client_opt.external = ['vscode'];


### PR DESCRIPTION
Fixes https://github.com/mark-wiemer/ahkpp/issues/571

Previously, when trying to set the interpreter path, the command sometimes failed silently. Specifically, if none of the `v2.file` settings were customized anywhere (global/user, workspace, or workspace folder), the `from: ConfigurationTarget` value was `undefined` instead of being set to a valid enum value.

This PR fixes that by setting `from` to `Global` and updates some minor metadata to test the fix.

This is a slight design change (thqby's extension apparently defaulted to `Workspace`, not `Global`), but the behavior was apparently never working in this extension, so it's not a breaking change.